### PR TITLE
[WIP] Add allowsBack setting

### DIFF
--- a/ios/Classes/FlutterWebviewPlugin.m
+++ b/ios/Classes/FlutterWebviewPlugin.m
@@ -85,6 +85,7 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     NSNumber *withZoom = call.arguments[@"withZoom"];
     NSNumber *scrollBar = call.arguments[@"scrollBar"];
     NSNumber *withJavascript = call.arguments[@"withJavascript"];
+    NSNumber *allowsBack = call.arguments[@"allowsBack"];
     _invalidUrlRegex = call.arguments[@"invalidUrlRegex"];
 
     if (clearCache != (id)[NSNull null] && [clearCache boolValue]) {
@@ -114,6 +115,7 @@ static NSString *const CHANNEL_NAME = @"flutter_webview_plugin";
     self.webview.hidden = [hidden boolValue];
     self.webview.scrollView.showsHorizontalScrollIndicator = [scrollBar boolValue];
     self.webview.scrollView.showsVerticalScrollIndicator = [scrollBar boolValue];
+    self.webview.allowsBackForwardNavigationGestures = [allowsBack boolValue];
     
     [self.webview addObserver:self forKeyPath:@"estimatedProgress" options:NSKeyValueObservingOptionNew context:NULL];
 

--- a/lib/src/base.dart
+++ b/lib/src/base.dart
@@ -116,6 +116,7 @@ class FlutterWebviewPlugin {
   /// - [scrollBar]: enable or disable scrollbar
   /// - [supportMultipleWindows] enable multiple windows support in Android
   /// - [invalidUrlRegex] is the regular expression of URLs that web view shouldn't load.
+  /// - [allowsBack] enable swipe gesture in iOS
   /// For example, when webview is redirected to a specific URL, you want to intercept
   /// this process by stopping loading this URL and replacing webview by another screen.
   Future<Null> launch(String url, {
@@ -138,6 +139,7 @@ class FlutterWebviewPlugin {
     String invalidUrlRegex,
     bool geolocationEnabled,
     bool debuggingEnabled,
+    bool allowsBack,
   }) async {
     final args = <String, dynamic>{
       'url': url,
@@ -158,6 +160,7 @@ class FlutterWebviewPlugin {
       'invalidUrlRegex': invalidUrlRegex,
       'geolocationEnabled': geolocationEnabled ?? false,
       'debuggingEnabled': debuggingEnabled ?? false,
+      'allowsBack': allowsBack ?? true,
     };
 
     if (headers != null) {

--- a/lib/src/webview_scaffold.dart
+++ b/lib/src/webview_scaffold.dart
@@ -34,6 +34,7 @@ class WebviewScaffold extends StatefulWidget {
     this.invalidUrlRegex,
     this.geolocationEnabled,
     this.debuggingEnabled = false,
+    this.allowsBack,
   }) : super(key: key);
 
   final PreferredSizeWidget appBar;
@@ -60,6 +61,7 @@ class WebviewScaffold extends StatefulWidget {
   final String invalidUrlRegex;
   final bool geolocationEnabled;
   final bool debuggingEnabled;
+  final bool allowsBack;
 
   @override
   _WebviewScaffoldState createState() => _WebviewScaffoldState();
@@ -157,6 +159,7 @@ class _WebviewScaffoldState extends State<WebviewScaffold> {
               invalidUrlRegex: widget.invalidUrlRegex,
               geolocationEnabled: widget.geolocationEnabled,
               debuggingEnabled: widget.debuggingEnabled,
+              allowsBack: widget.allowsBack,
             );
           } else {
             if (_rect != value) {


### PR DESCRIPTION
iOSの `WKWebView.allowsBackForwardNavigationGestures` を変更する設定を追加した。

Swipeで `history.back` はできるようになったけど、 
この問題 https://github.com/fluttercommunity/flutter_webview_plugin/issues/107 があって、
元の画面に戻ることができなくて、中途半端に戻ろうとしてフリーズすることがある。
